### PR TITLE
Added Mastodon Luce Light

### DIFF
--- a/app/javascript/flavours/glitch/styles/mastodon-light-neo.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-light-neo.scss
@@ -1,0 +1,265 @@
+// Set variables
+$ui-base-color: #d9e1e8;
+$ui-base-lighter-color: darken($ui-base-color, 57%);
+$ui-highlight-color: #2b90d9;
+$ui-primary-color: darken($ui-highlight-color, 28%);
+$ui-secondary-color: #282c37;
+
+$primary-text-color: black;
+$base-overlay-background: $ui-base-color;
+
+$login-button-color: white;
+$account-background-color: white;
+
+// Import defaults
+@import 'index';
+
+// Change the color of the log in button
+.button {
+  &.button-alternative-2 {
+    color: $login-button-color;
+  }
+}
+
+button.column-header__back-button {
+  color: $ui-secondary-color;
+}
+
+// Change columns' default background colors
+.column {
+  > .scrollable {
+    background: lighten($ui-base-color, 13%);
+  }
+}
+
+.status.collapsed .status__content:after {
+  background: linear-gradient(rgba(lighten($ui-base-color, 13%), 0), rgba(lighten($ui-base-color, 13%), 1));
+}
+
+.drawer__inner {
+  background: $ui-base-color;
+}
+
+.drawer--account {
+  padding-bottom: 0px;
+}
+
+.drawer > .contents {
+  background: $ui-base-color url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 234.80078 31.757813" width="234.80078" height="31.757812"><path d="M19.599609 0c-1.05 0-2.10039.375-2.90039 1.125L0 16.925781v14.832031h234.80078V17.025391l-16.5-15.900391c-1.6-1.5-4.20078-1.5-5.80078 0l-13.80078 13.099609c-1.6 1.5-4.19883 1.5-5.79883 0L179.09961 1.125c-1.6-1.5-4.19883-1.5-5.79883 0L159.5 14.224609c-1.6 1.5-4.20078 1.5-5.80078 0L139.90039 1.125c-1.6-1.5-4.20078-1.5-5.80078 0l-13.79883 13.099609c-1.6 1.5-4.20078 1.5-5.80078 0L100.69922 1.125c-1.600001-1.5-4.198829-1.5-5.798829 0l-13.59961 13.099609c-1.6 1.5-4.200781 1.5-5.800781 0L61.699219 1.125c-1.6-1.5-4.198828-1.5-5.798828 0L42.099609 14.224609c-1.6 1.5-4.198828 1.5-5.798828 0L22.5 1.125C21.7.375 20.649609 0 19.599609 0z" fill="#{hex-color(lighten($ui-base-color, 13%))}"/></svg>') no-repeat bottom / 100% auto !important;
+
+  .mastodon {
+    filter: contrast(75%) brightness(75%) !important;
+  }
+
+  .mbstobon-0 { 
+    background: transparent;
+  }
+}
+
+// Change the default appearance of the content warning button
+.status__content {
+
+  .status__content__spoiler-link {
+
+    background: darken($ui-base-color, 30%);
+
+    &:hover {
+      background: darken($ui-base-color, 35%);
+      text-decoration: none;
+    }
+
+  }
+
+}
+
+// Change the default appearance of the action buttons
+.icon-button {
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: darken($ui-base-color, 40%);
+    transition: color 200ms ease-out;
+  }
+
+  &.disabled {
+    color: darken($ui-base-color, 30%);
+  }
+
+}
+
+.status {
+  &.status-direct {
+    .icon-button.disabled {
+      color: darken($ui-base-color, 30%);
+    }
+  }
+}
+
+// Change the colors used in the dropdown menu
+.dropdown-menu {
+  background: $ui-base-color;
+}
+
+.dropdown-menu__arrow {
+
+  &.left {
+    border-left-color: $ui-base-color;
+  }
+
+  &.top {
+    border-top-color: $ui-base-color;
+  }
+
+  &.bottom {
+    border-bottom-color: $ui-base-color;
+  }
+
+  &.right {
+    border-right-color: $ui-base-color;
+  }
+
+}
+
+.dropdown-menu__item {
+  a {
+    background: $ui-base-color;
+    color: $ui-secondary-color;
+  }
+}
+
+// Change the default color of several parts of the compose form
+
+// editor's note: i have zero idea why editing this outside of 
+// .compose actually changes the value and frankly it pisses me
+// off
+
+// editor's note 2: if shit breaks try removing the explicit html
+// tag references, idk if it'll work web browsers are witchcraft
+
+article.composer--reply {
+  background: darken($ui-base-color, 10%);
+  box-shadow: unset;
+
+  div.content {
+    p {
+      color: $ui-secondary-color !important;
+    }
+  }
+}
+
+span.display-name__account {
+  color: $ui-secondary-color;
+
+}
+
+.composer--publisher {
+  button.button {
+      background: $ui-primary-color; // this breaks the color transition
+                                     // i also sorta don't really care?
+      color: $ui-base-color;
+  }
+}
+
+
+.composer {
+
+  .composer--spoiler input, .composer--textarea textarea {
+    color: darken($ui-base-color, 80%);
+
+    &::placeholder {
+      color: darken($ui-base-color, 70%);
+    }
+  }
+
+  strong {
+    color: darken($ui-secondary-color, 10%);
+  }
+
+  .composer--options {
+    background: darken($ui-base-color, 10%);
+    box-shadow: unset;
+  }
+
+  .composer--options--dropdown--content--item {
+    color: $ui-primary-color;
+    
+    strong {
+      color: $ui-primary-color;
+    }
+
+  }
+}
+
+// Change the default color used for the text in an empty column or on the error column
+.empty-column-indicator,
+.error-column {
+  color: darken($ui-base-color, 60%);
+}
+
+// Change the default colors used on some parts of the profile pages
+.activity-stream-tabs {
+
+  background: $account-background-color;
+
+  a {
+    &.active {
+      color: $ui-primary-color;
+      }
+  }
+
+}
+
+.activity-stream {
+
+  .entry {
+    background: $account-background-color;
+  }
+
+  .status.light {
+
+    .status__content {
+      color: $primary-text-color;
+    }
+
+    .display-name {
+      strong {
+        color: $primary-text-color;
+      }
+    }
+
+  }
+
+}
+
+.drawer--account {
+  height: 0% !important; // fuck you inline css
+
+}
+
+.accounts-grid {
+  .account-grid-card {
+
+    .controls {
+      .icon-button {
+        color: $ui-secondary-color;
+      }
+    }
+
+    .name {
+      a {
+        color: $primary-text-color;
+      }
+    }
+
+    .username {
+      color: $ui-secondary-color;
+    }
+
+    .account__header__content {
+      color: $primary-text-color;
+    }
+
+  }
+}
+

--- a/app/javascript/flavours/glitch/styles/mastodon-light-neo.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-light-neo.scss
@@ -233,8 +233,8 @@ span.display-name__account {
 }
 
 .drawer--account {
-  height: 0% !important; // fuck you inline css
-
+  height: 84% !important; // fuck you inline css
+  padding-bottom: 0px !important;
 }
 
 .accounts-grid {

--- a/app/javascript/skins/glitch/mastodon-light-neo/common.scss
+++ b/app/javascript/skins/glitch/mastodon-light-neo/common.scss
@@ -1,0 +1,6 @@
+@import 'flavours/glitch/styles/mastodon-light-neo';
+
+.mastodon {
+  background: url(~images/elephant_ui_plane.svg) no-repeat 0 100%/contain !important;
+  filter: none !important;
+}

--- a/app/javascript/skins/glitch/mastodon-light-neo/names.yml
+++ b/app/javascript/skins/glitch/mastodon-light-neo/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    glitch:
+      mastodon-luce-light: Mastodon Luce Light

--- a/app/javascript/skins/glitch/mastodon-light-neo/names.yml
+++ b/app/javascript/skins/glitch/mastodon-light-neo/names.yml
@@ -1,4 +1,4 @@
 en:
   skins:
     glitch:
-      mastodon-luce-light: Mastodon Luce Light
+      mastodon-light-neo: Mastodon Luce Light


### PR DESCRIPTION
added a new glitch social skin, mastodon luce light (which stands for Mastodon Light Light because I'm stupid), which is a minor modification to mastodon light that makes the post section significantly less ugly. Mostly because if the sleeping flavor is dying I better make a glitch skin I'm comfortable using.

> Mastodon Luce Light
![image](https://user-images.githubusercontent.com/30452393/41787517-464ce410-760e-11e8-9691-63f6361de90e.png)

![image](https://user-images.githubusercontent.com/30452393/41787746-f9ca6814-760e-11e8-95f3-eb7cfd0761cd.png)


> Mastodon (Light)
![image](https://user-images.githubusercontent.com/30452393/41787572-6d2e1644-760e-11e8-8fe4-f692f6c86ca6.png)

![image](https://user-images.githubusercontent.com/30452393/41787799-25662332-760f-11e8-922c-9a56da8521e0.png)


Take note of the hinge, which actually overlays on top of text boxes/the reply quote.

Other changes include a revert to the original mastodon elefriend instead of the glitch elefriend, and the Back button on posts has changed color to match the rest of the header text.

I might come back and do some additional changes, but this is sort of the big annoyances I hated about the light skin.